### PR TITLE
Add SQLite storage for scan history

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ Make sure pytest is installed and run tests from the repository root:
 ```bash
 pytest
 ```
+
+The application stores scan history in a SQLite database located at
+`data/devices.db` by default. You can override the location by setting the
+`DB_PATH` environment variable.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,17 @@
+import os
+import sqlite3
+from utils import db
+
+
+def test_save_and_get_scan_results(tmp_path, monkeypatch):
+    test_db = tmp_path / "test.db"
+    monkeypatch.setenv('DB_PATH', str(test_db))
+    hosts = [
+        {'ip': '1.1.1.1', 'hostname': 'host', 'mac': '00:11', 'open_ports': [80, 443]},
+        {'ip': '2.2.2.2', 'hostname': 'host2', 'mac': '00:22', 'open_ports': []},
+    ]
+    scan_id = db.save_scan_results(hosts, db_path=str(test_db))
+    results = db.get_scan_results(scan_id, db_path=str(test_db))
+    assert len(results) == 2
+    assert results[0]['ip'] == '1.1.1.1'
+    assert 80 in results[0]['open_ports']

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,0 +1,67 @@
+import sqlite3
+import os
+from contextlib import contextmanager
+
+DB_PATH = os.environ.get('DB_PATH', os.path.join('data', 'devices.db'))
+
+@contextmanager
+def get_connection(db_path: str = DB_PATH):
+    conn = sqlite3.connect(db_path)
+    try:
+        yield conn
+    finally:
+        conn.commit()
+        conn.close()
+
+def initialize_db(conn: sqlite3.Connection):
+    cur = conn.cursor()
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS scans (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )"""
+    )
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS hosts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                scan_id INTEGER,
+                ip TEXT,
+                hostname TEXT,
+                mac TEXT,
+                open_ports TEXT,
+                FOREIGN KEY(scan_id) REFERENCES scans(id)
+            )"""
+    )
+    conn.commit()
+
+def save_scan_results(hosts, db_path: str = DB_PATH):
+    with get_connection(db_path) as conn:
+        initialize_db(conn)
+        cur = conn.cursor()
+        cur.execute("INSERT INTO scans DEFAULT VALUES")
+        scan_id = cur.lastrowid
+        for host in hosts:
+            ports = ','.join(str(p) for p in host.get('open_ports', []))
+            cur.execute(
+                "INSERT INTO hosts (scan_id, ip, hostname, mac, open_ports) VALUES (?, ?, ?, ?, ?)",
+                (scan_id, host.get('ip'), host.get('hostname'), host.get('mac'), ports)
+            )
+        conn.commit()
+        return scan_id
+
+def get_scan_results(scan_id: int, db_path: str = DB_PATH):
+    with get_connection(db_path) as conn:
+        initialize_db(conn)
+        cur = conn.cursor()
+        cur.execute("SELECT ip, hostname, mac, open_ports FROM hosts WHERE scan_id=?", (scan_id,))
+        rows = cur.fetchall()
+        result = []
+        for ip, hostname, mac, ports in rows:
+            open_ports = [int(p) for p in ports.split(',') if p]
+            result.append({
+                'ip': ip,
+                'hostname': hostname,
+                'mac': mac,
+                'open_ports': open_ports
+            })
+        return result

--- a/web/app.py
+++ b/web/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template
 from scanner.discover import scan_subnet, enrich_all_hosts
+from utils.db import save_scan_results
 
 app = Flask(__name__)
 
@@ -8,6 +9,7 @@ def dashboard():
     subnet = "192.168.1.0/24"
     live_hosts = scan_subnet(subnet)
     enriched_hosts = enrich_all_hosts(live_hosts)
+    save_scan_results(enriched_hosts)
     return render_template("dashboard.html", hosts=enriched_hosts)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- store scan history in SQLite via `utils.db` helpers
- log each dashboard scan to the database
- document database usage
- test database save/retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f4c887e68832e808304aa48dc18de