### PR TITLE
Add subnet input and scan button

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ pip install -r requirements.txt
 python web/app.py
 ```
 
-The default subnet scanned is `192.168.1.0/24`. Edit `web/app.py` if you need to
-scan a different range. Once running, visit `http://localhost:5000` to view the
-dashboard.
+Once running, visit `http://localhost:5000` and enter the subnet you want to
+scan. The scanner only runs when you submit the form, defaulting to
+`192.168.1.0/24` if no subnet is provided.
 
 ## Running Tests
 

--- a/web/app.py
+++ b/web/app.py
@@ -1,16 +1,19 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, request
 from scanner.discover import scan_subnet, enrich_all_hosts
 from utils.db import save_scan_results
 
 app = Flask(__name__)
 
-@app.route("/")
+@app.route("/", methods=["GET", "POST"])
 def dashboard():
     subnet = "192.168.1.0/24"
-    live_hosts = scan_subnet(subnet)
-    enriched_hosts = enrich_all_hosts(live_hosts)
-    save_scan_results(enriched_hosts)
-    return render_template("dashboard.html", hosts=enriched_hosts)
+    hosts = []
+    if request.method == "POST":
+        subnet = request.form.get("subnet", subnet)
+        live_hosts = scan_subnet(subnet)
+        hosts = enrich_all_hosts(live_hosts)
+        save_scan_results(hosts)
+    return render_template("dashboard.html", hosts=hosts, subnet=subnet)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -7,6 +7,12 @@
 </head>
 <body>
     <h1>Discovered Devices</h1>
+    <form method="post">
+        <label for="subnet">Subnet to Scan:</label>
+        <input type="text" id="subnet" name="subnet" value="{{ subnet }}">
+        <button type="submit">Scan</button>
+    </form>
+    {% if hosts %}
     <table border="1">
         <tr>
             <th>IP</th>
@@ -23,5 +29,6 @@
         </tr>
         {% endfor %}
     </table>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow scanning a specified subnet via a form
- update the dashboard template with a subnet field and scan button
- document subnet selection in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f51302c2c832e903fdffcd7b9b206