### PR TITLE
Add loading animation while scanning

### DIFF
--- a/web/static/script.js
+++ b/web/static/script.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.querySelector('form');
+    const loading = document.getElementById('loading');
+    if (form) {
+        form.addEventListener('submit', function () {
+            if (loading) {
+                loading.style.display = 'flex';
+            }
+        });
+    }
+});

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -255,3 +255,31 @@ td:first-child:hover {
     cursor: pointer;
     text-shadow: 0 0 5px #b41c21;
 }
+/* Loading overlay */
+
+#loading {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+}
+
+#loading .spinner {
+    border: 8px solid #f3f3f3;
+    border-top: 8px solid #B41C21;
+    border-radius: 50%;
+    width: 60px;
+    height: 60px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -12,6 +12,9 @@
         <input type="text" id="subnet" name="subnet" value="{{ subnet }}">
         <button type="submit">Scan</button>
     </form>
+    <div id="loading">
+        <div class="spinner"></div>
+    </div>
     {% if hosts %}
     <table border="1">
         <tr>
@@ -30,5 +33,6 @@
         {% endfor %}
     </table>
     {% endif %}
+    <script src="../static/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a small JS file that toggles a loading overlay
- style the loading overlay and spinner
- include overlay markup and script in dashboard template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f52e47d70832eb6603d0315c01f72