### PR TITLE
Display latest stored scan results

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,3 +27,24 @@ def test_env_var_db_path_used(tmp_path, monkeypatch):
     results = db.get_scan_results(scan_id)
     assert results[0]['ip'] == '3.3.3.3'
     assert env_db.exists()
+
+
+def test_get_latest_scan_results(tmp_path):
+    db_path = tmp_path / "latest.db"
+    hosts1 = [
+        {'ip': '1.1.1.1', 'hostname': 'h1', 'mac': 'm1', 'open_ports': [80]}
+    ]
+    hosts2 = [
+        {'ip': '2.2.2.2', 'hostname': 'h2', 'mac': 'm2', 'open_ports': [22]}
+    ]
+    db.save_scan_results(hosts1, db_path=str(db_path))
+    db.save_scan_results(hosts2, db_path=str(db_path))
+    results = db.get_latest_scan_results(db_path=str(db_path))
+    assert len(results) == 1
+    assert results[0]['ip'] == '2.2.2.2'
+
+
+def test_get_latest_scan_results_empty(tmp_path):
+    db_path = tmp_path / "empty.db"
+    results = db.get_latest_scan_results(db_path=str(db_path))
+    assert results == []

--- a/utils/db.py
+++ b/utils/db.py
@@ -71,3 +71,15 @@ def get_scan_results(scan_id: int, db_path: str = None):
                 'open_ports': open_ports
             })
         return result
+
+def get_latest_scan_results(db_path: str = None):
+    """Return hosts from the most recent scan if available."""
+    with get_connection(db_path) as conn:
+        initialize_db(conn)
+        cur = conn.cursor()
+        cur.execute("SELECT id FROM scans ORDER BY id DESC LIMIT 1")
+        row = cur.fetchone()
+        if not row:
+            return []
+        latest_id = row[0]
+        return get_scan_results(latest_id, db_path=db_path)

--- a/web/app.py
+++ b/web/app.py
@@ -1,13 +1,13 @@
 from flask import Flask, render_template, request
 from scanner.discover import scan_subnet, enrich_all_hosts
-from utils.db import save_scan_results
+from utils.db import save_scan_results, get_latest_scan_results
 
 app = Flask(__name__)
 
 @app.route("/", methods=["GET", "POST"])
 def dashboard():
     subnet = "192.168.1.0/24"
-    hosts = []
+    hosts = get_latest_scan_results()
     if request.method == "POST":
         subnet = request.form.get("subnet", subnet)
         live_hosts = scan_subnet(subnet)


### PR DESCRIPTION
## Summary
- provide `get_latest_scan_results` utility
- show latest scan data on dashboard when page loads
- test new utility functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f564c49d0832e90b545372c2b08fd