### PR TITLE
Add scan history retrieval

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -48,3 +48,22 @@ def test_get_latest_scan_results_empty(tmp_path):
     db_path = tmp_path / "empty.db"
     results = db.get_latest_scan_results(db_path=str(db_path))
     assert results == []
+
+
+def test_get_scan_history(tmp_path):
+    db_path = tmp_path / "history.db"
+    hosts1 = [{'ip': '1.1.1.1', 'hostname': 'h1', 'mac': 'm1', 'open_ports': []}]
+    hosts2 = [{'ip': '2.2.2.2', 'hostname': 'h2', 'mac': 'm2', 'open_ports': []}]
+    id1 = db.save_scan_results(hosts1, db_path=str(db_path))
+    id2 = db.save_scan_results(hosts2, db_path=str(db_path))
+    history = db.get_scan_history(db_path=str(db_path))
+    assert [record['id'] for record in history] == [id1, id2]
+
+
+def test_get_scan_history_env_var_used(tmp_path, monkeypatch):
+    env_db = tmp_path / "env_history.db"
+    monkeypatch.setenv('DB_PATH', str(env_db))
+    db.save_scan_results([{'ip': '1.1.1.1', 'hostname': 'h1', 'mac': 'm1', 'open_ports': []}])
+    history = db.get_scan_history()
+    assert len(history) == 1
+    assert env_db.exists()

--- a/utils/db.py
+++ b/utils/db.py
@@ -83,3 +83,16 @@ def get_latest_scan_results(db_path: str = None):
             return []
         latest_id = row[0]
         return get_scan_results(latest_id, db_path=db_path)
+
+
+def get_scan_history(db_path: str = None):
+    """Return a list of all scans with their timestamps."""
+    with get_connection(db_path) as conn:
+        initialize_db(conn)
+        cur = conn.cursor()
+        cur.execute("SELECT id, timestamp FROM scans ORDER BY id ASC")
+        rows = cur.fetchall()
+        return [
+            {"id": row[0], "timestamp": row[1]}
+            for row in rows
+        ]


### PR DESCRIPTION
## Summary
- implement `get_scan_history` to list all previous scans
- test the new DB helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f572e2444832eb54477a152af6854