### PR TITLE
Improve host discovery with ping sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Network Discovery Dashboard
 
-Simple dashboard for discovering devices on a local subnet.
+Simple dashboard for discovering devices on a local subnet. The discovery
+process performs a lightweight ping sweep of every host in the specified
+subnet and then gathers additional details for any responding device.
 
 ## Quick Start
 

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,32 +1,17 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from scanner import discover
 
 
-def mock_socket_factory(connect_return=0):
-    class DummySocket:
-        def __init__(self, return_value):
-            self.return_value = return_value
-        def settimeout(self, timeout):
-            pass
-        def connect_ex(self, *args, **kwargs):
-            return self.return_value
-        def __enter__(self):
-            return self
-        def __exit__(self, exc_type, exc, tb):
-            pass
-    def factory(*args, **kwargs):
-        return DummySocket(connect_return)
-    return factory
-
-
-def test_is_alive_open_port():
-    with patch('scanner.discover.socket.socket', side_effect=mock_socket_factory(0)):
+def test_is_alive_ping_success():
+    mock_result = MagicMock(returncode=0)
+    with patch('scanner.discover.subprocess.run', return_value=mock_result):
         ip = '192.168.1.1'
         assert discover.is_alive(ip) == ip
 
 
-def test_is_alive_all_ports_closed():
-    with patch('scanner.discover.socket.socket', side_effect=mock_socket_factory(1)):
+def test_is_alive_ping_failure():
+    mock_result = MagicMock(returncode=1)
+    with patch('scanner.discover.subprocess.run', return_value=mock_result):
         ip = '192.168.1.2'
         assert discover.is_alive(ip) is None
 


### PR DESCRIPTION
## Summary
- ping hosts to determine if they're alive instead of checking common ports
- update documentation to reflect ping sweep behaviour
- adjust tests for new host discovery method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f584d1ecc832eb2b48f2fa392daa4