### PR TITLE
Add GRIT style nav bar

### DIFF
--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -6,6 +6,15 @@
     <link rel="stylesheet" href="../static/style.css">
 </head>
 <body>
+    <!-- Navigation Bar -->
+    <nav class="navbar">
+        <div class="container">
+            <h1 class="logo">GRIT</h1>
+            <ul class="nav-links">
+                <li><a href="https://grit.claws.net">Home</a></li>
+            </ul>
+        </div>
+    </nav>
     <h1>Discovered Devices</h1>
     <form method="post">
         <label for="subnet">Subnet to Scan:</label>


### PR DESCRIPTION
## Summary
- add GRIT navigation bar with logo and Home link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5a087220832eaf2075c4b4431a6c