### PR TITLE
Add subnet validation for web form

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,11 @@
+import pytest
+from utils.helpers import sanitize_subnet
+
+
+def test_sanitize_subnet_valid():
+    assert sanitize_subnet('192.168.1.0/24') == '192.168.1.0/24'
+
+
+def test_sanitize_subnet_invalid():
+    with pytest.raises(ValueError):
+        sanitize_subnet("1.1.1.0/24; DROP TABLE")

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,0 +1,25 @@
+import ipaddress
+import re
+
+def sanitize_subnet(subnet: str) -> str:
+    """Validate and normalize a subnet string.
+
+    Parameters
+    ----------
+    subnet: str
+        The user provided subnet.
+
+    Returns
+    -------
+    str
+        The canonicalized subnet.
+
+    Raises
+    ------
+    ValueError
+        If the subnet is not valid.
+    """
+    if not re.fullmatch(r'[0-9./]+', subnet.strip()):
+        raise ValueError('Invalid subnet format')
+    network = ipaddress.ip_network(subnet, strict=False)
+    return str(network)

--- a/web/app.py
+++ b/web/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, render_template, request
 from scanner.discover import scan_subnet, enrich_all_hosts
 from utils.db import save_scan_results, get_latest_scan_results
+from utils.helpers import sanitize_subnet
 
 app = Flask(__name__)
 
@@ -9,10 +10,15 @@ def dashboard():
     subnet = "192.168.1.0/24"
     hosts = get_latest_scan_results()
     if request.method == "POST":
-        subnet = request.form.get("subnet", subnet)
-        live_hosts = scan_subnet(subnet)
-        hosts = enrich_all_hosts(live_hosts)
-        save_scan_results(hosts)
+        raw_subnet = request.form.get("subnet", subnet)
+        try:
+            subnet = sanitize_subnet(raw_subnet)
+            live_hosts = scan_subnet(subnet)
+            hosts = enrich_all_hosts(live_hosts)
+            save_scan_results(hosts)
+        except ValueError:
+            # Invalid input - ignore to avoid injection or crashes
+            pass
     return render_template("dashboard.html", hosts=hosts, subnet=subnet)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `sanitize_subnet` helper to validate user provided subnet strings
- update Flask route to use sanitized subnet
- test subnet sanitization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f641420c0832e97384a053ece4af5