### PR TITLE
Add nmap-based OS and MAC detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ subnet and then gathers additional details for any responding device.
 
 ## Quick Start
 
-Install the required packages and make sure the `nmap` command is available, then launch the Flask application:
+Install the required packages and ensure the `nmap` command is available (root privileges improve OS detection), then launch the Flask application:
 
 ```bash
 pip install -r requirements.txt
@@ -16,6 +16,10 @@ python web/app.py
 Once running, visit `http://localhost:5000` and enter the subnet you want to
 scan. The scanner only runs when you submit the form, defaulting to
 `192.168.1.0/24` if no subnet is provided.
+
+Nmap is used for OS fingerprinting and for detecting open ports. If `nmap`
+is not installed, the application falls back to a basic socket-based port
+scan but OS information may be unavailable.
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ subnet and then gathers additional details for any responding device.
 
 ## Quick Start
 
-Install the required packages and launch the Flask application:
+Install the required packages and make sure the `nmap` command is available, then launch the Flask application:
 
 ```bash
 pip install -r requirements.txt

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -67,3 +67,14 @@ def test_get_scan_history_env_var_used(tmp_path, monkeypatch):
     history = db.get_scan_history()
     assert len(history) == 1
     assert env_db.exists()
+
+
+def test_db_directory_created(tmp_path):
+    db_path = tmp_path / "nested" / "created.db"
+    # parent directory does not exist yet
+    assert not db_path.parent.exists()
+    db.save_scan_results([
+        {'ip': '1.1.1.1', 'hostname': 'h', 'mac': 'm', 'os': 'Linux', 'open_ports': []}
+    ], db_path=str(db_path))
+    # connection should create the directory automatically
+    assert db_path.exists()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -7,8 +7,8 @@ def test_save_and_get_scan_results(tmp_path, monkeypatch):
     test_db = tmp_path / "test.db"
     monkeypatch.setenv('DB_PATH', str(test_db))
     hosts = [
-        {'ip': '1.1.1.1', 'hostname': 'host', 'mac': '00:11', 'open_ports': [80, 443]},
-        {'ip': '2.2.2.2', 'hostname': 'host2', 'mac': '00:22', 'open_ports': []},
+        {'ip': '1.1.1.1', 'hostname': 'host', 'mac': '00:11', 'os': 'Linux', 'open_ports': [80, 443]},
+        {'ip': '2.2.2.2', 'hostname': 'host2', 'mac': '00:22', 'os': 'Linux', 'open_ports': []},
     ]
     scan_id = db.save_scan_results(hosts, db_path=str(test_db))
     results = db.get_scan_results(scan_id, db_path=str(test_db))
@@ -21,7 +21,7 @@ def test_env_var_db_path_used(tmp_path, monkeypatch):
     env_db = tmp_path / "env.db"
     monkeypatch.setenv('DB_PATH', str(env_db))
     hosts = [
-        {'ip': '3.3.3.3', 'hostname': 'host3', 'mac': '00:33', 'open_ports': []}
+        {'ip': '3.3.3.3', 'hostname': 'host3', 'mac': '00:33', 'os': 'Linux', 'open_ports': []}
     ]
     scan_id = db.save_scan_results(hosts)
     results = db.get_scan_results(scan_id)
@@ -32,10 +32,10 @@ def test_env_var_db_path_used(tmp_path, monkeypatch):
 def test_get_latest_scan_results(tmp_path):
     db_path = tmp_path / "latest.db"
     hosts1 = [
-        {'ip': '1.1.1.1', 'hostname': 'h1', 'mac': 'm1', 'open_ports': [80]}
+        {'ip': '1.1.1.1', 'hostname': 'h1', 'mac': 'm1', 'os': 'Linux', 'open_ports': [80]}
     ]
     hosts2 = [
-        {'ip': '2.2.2.2', 'hostname': 'h2', 'mac': 'm2', 'open_ports': [22]}
+        {'ip': '2.2.2.2', 'hostname': 'h2', 'mac': 'm2', 'os': 'Linux', 'open_ports': [22]}
     ]
     db.save_scan_results(hosts1, db_path=str(db_path))
     db.save_scan_results(hosts2, db_path=str(db_path))
@@ -52,8 +52,8 @@ def test_get_latest_scan_results_empty(tmp_path):
 
 def test_get_scan_history(tmp_path):
     db_path = tmp_path / "history.db"
-    hosts1 = [{'ip': '1.1.1.1', 'hostname': 'h1', 'mac': 'm1', 'open_ports': []}]
-    hosts2 = [{'ip': '2.2.2.2', 'hostname': 'h2', 'mac': 'm2', 'open_ports': []}]
+    hosts1 = [{'ip': '1.1.1.1', 'hostname': 'h1', 'mac': 'm1', 'os': 'Linux', 'open_ports': []}]
+    hosts2 = [{'ip': '2.2.2.2', 'hostname': 'h2', 'mac': 'm2', 'os': 'Linux', 'open_ports': []}]
     id1 = db.save_scan_results(hosts1, db_path=str(db_path))
     id2 = db.save_scan_results(hosts2, db_path=str(db_path))
     history = db.get_scan_history(db_path=str(db_path))
@@ -63,7 +63,7 @@ def test_get_scan_history(tmp_path):
 def test_get_scan_history_env_var_used(tmp_path, monkeypatch):
     env_db = tmp_path / "env_history.db"
     monkeypatch.setenv('DB_PATH', str(env_db))
-    db.save_scan_results([{'ip': '1.1.1.1', 'hostname': 'h1', 'mac': 'm1', 'open_ports': []}])
+    db.save_scan_results([{'ip': '1.1.1.1', 'hostname': 'h1', 'mac': 'm1', 'os': 'Linux', 'open_ports': []}])
     history = db.get_scan_history()
     assert len(history) == 1
     assert env_db.exists()

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -37,3 +37,15 @@ OS details: Linux 3.X
         os_name, mac = discover.get_os_and_mac('1.1.1.1')
     assert os_name == 'Linux 3.X'
     assert mac == '00:11:22:33:44:55'
+
+
+def test_get_open_ports_nmap_parse():
+    sample_output = """
+PORT     STATE SERVICE
+22/tcp   open  ssh
+80/tcp   open  http
+443/tcp  open  https
+"""
+    with patch('scanner.discover.subprocess.check_output', return_value=sample_output.encode()):
+        ports = discover.get_open_ports('1.1.1.1', ports=[22, 80, 443])
+    assert ports == [22, 80, 443]

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -20,7 +20,20 @@ def test_enrich_single_host_keys():
     ip = '192.168.1.3'
     with patch('scanner.discover.get_hostname', return_value='host'):
         with patch('scanner.discover.get_mac', return_value='00:11:22:33:44:55'):
-            with patch('scanner.discover.get_open_ports', return_value=[80]):
-                result = discover.enrich_single_host(ip)
+            with patch('scanner.discover.get_os', return_value='Linux'):
+                with patch('scanner.discover.get_open_ports', return_value=[80]):
+                    result = discover.enrich_single_host(ip)
     assert isinstance(result, dict)
-    assert set(result.keys()) == {'ip', 'hostname', 'mac', 'open_ports'}
+    assert set(result.keys()) == {'ip', 'hostname', 'mac', 'os', 'open_ports'}
+
+
+def test_get_os_and_mac_parse():
+    sample_output = """
+Host is up (0.001s latency).
+MAC Address: 00:11:22:33:44:55 (Vendor)
+OS details: Linux 3.X
+"""
+    with patch('scanner.discover.subprocess.check_output', return_value=sample_output.encode()):
+        os_name, mac = discover.get_os_and_mac('1.1.1.1')
+    assert os_name == 'Linux 3.X'
+    assert mac == '00:11:22:33:44:55'

--- a/utils/db.py
+++ b/utils/db.py
@@ -12,6 +12,9 @@ def get_db_path() -> str:
 def get_connection(db_path: str = None):
     if db_path is None:
         db_path = get_db_path()
+    dirpath = os.path.dirname(db_path)
+    if dirpath:
+        os.makedirs(dirpath, exist_ok=True)
     conn = sqlite3.connect(db_path)
     try:
         yield conn

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -31,6 +31,7 @@
             <th>IP</th>
             <th>Hostname</th>
             <th>MAC Address</th>
+            <th>OS</th>
             <th>Open Ports</th>
         </tr>
         {% for host in hosts %}
@@ -38,6 +39,7 @@
             <td>{{ host.ip }}</td>
             <td>{{ host.hostname }}</td>
             <td>{{ host.mac }}</td>
+            <td>{{ host.os or 'Unknown' }}</td>
             <td>{{ host.open_ports | join(', ') }}</td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- integrate nmap scanning to gather OS and MAC info
- store OS info in database and display in dashboard
- update tests for new OS field
- document nmap requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f67bfd030832e837c85ddf9b4cbe6