### PR TITLE
Add OS column to dashboard

### DIFF
--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -31,6 +31,7 @@
             <th>IP</th>
             <th>Hostname</th>
             <th>MAC Address</th>
+            <th>OS</th>
             <th>Open Ports</th>
         </tr>
         {% for host in hosts %}
@@ -38,6 +39,7 @@
             <td>{{ host.ip }}</td>
             <td>{{ host.hostname }}</td>
             <td>{{ host.mac }}</td>
+            <td>{{ host.os or 'Unknown' }}</td>
             <td>{{ host.open_ports | join(', ') }}</td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- display OS information in the dashboard table
- show 'Unknown' if OS data is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7a0dd2c0832eb9cf0695f6d086d5